### PR TITLE
chore: revert to prettier-plugin-multiline-arrays@3 for Node.js 20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,59 +11,19 @@
             "peerDependencies": {
                 "@trivago/prettier-plugin-sort-imports": "^5.2.1",
                 "prettier": "^3.4.2",
-                "prettier-plugin-multiline-arrays": "^4.0.2"
-            }
-        },
-        "node_modules/@augment-vir/assert": {
-            "version": "31.8.0",
-            "resolved": "https://registry.npmjs.org/@augment-vir/assert/-/assert-31.8.0.tgz",
-            "integrity": "sha512-eRW+ILuZkMC+Ed1iKGo+cwZJbAqANnXfi/Q53OKbLroo0kZ6hYS6waJ559l3Awfxo8pKhBJtZ7uYW7amg17cxw==",
-            "license": "(MIT or CC0 1.0)",
-            "peer": true,
-            "dependencies": {
-                "@augment-vir/core": "^31.8.0",
-                "@date-vir/duration": "^7.1.2",
-                "deep-eql": "^5.0.2",
-                "expect-type": "^1.1.0",
-                "type-fest": "^4.32.0"
-            },
-            "engines": {
-                "node": ">=22"
+                "prettier-plugin-multiline-arrays": "^3.0.6"
             }
         },
         "node_modules/@augment-vir/common": {
-            "version": "31.8.0",
-            "resolved": "https://registry.npmjs.org/@augment-vir/common/-/common-31.8.0.tgz",
-            "integrity": "sha512-dYl5pCA22XVePOwtP//GU3NAPazml++8Ye3cpmwD0B034zV+Ss0msTL+bypWpBID/PoLvOBRhu7GMDo8GoEqOg==",
-            "license": "(MIT or CC0 1.0)",
+            "version": "28.2.4",
+            "resolved": "https://registry.npmjs.org/@augment-vir/common/-/common-28.2.4.tgz",
+            "integrity": "sha512-5Ib0OX7YlxAuFrG+MAoTsz6RlKMcbdMdoNGcEEKH/ezc/ZKMy/IHZ9Z/ZcCHYopZ4ocGXzVY4KUOiJ8+CXXvTA==",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@augment-vir/assert": "^31.8.0",
-                "@augment-vir/core": "^31.8.0",
-                "@date-vir/duration": "^7.1.2",
-                "ansi-styles": "^6.2.1",
-                "json5": "^2.2.3",
-                "type-fest": "^4.32.0",
-                "typed-event-target": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=22"
-            }
-        },
-        "node_modules/@augment-vir/core": {
-            "version": "31.8.0",
-            "resolved": "https://registry.npmjs.org/@augment-vir/core/-/core-31.8.0.tgz",
-            "integrity": "sha512-StehNJTNq56et+iQ/FI8mjqLbK+++AsHzv/P4+fI1V+HGVQ+dWDbE6OCuINlLKs17kMcFMhERYKUmJehCDUnBg==",
-            "license": "(MIT or CC0 1.0)",
-            "peer": true,
-            "dependencies": {
-                "@date-vir/duration": "^7.1.2",
                 "browser-or-node": "^3.0.0",
-                "json5": "^2.2.3",
-                "type-fest": "^4.32.0"
-            },
-            "engines": {
-                "node": ">=22"
+                "run-time-assertions": "^1.5.1",
+                "type-fest": "^4.20.1"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -182,21 +142,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@date-vir/duration": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/@date-vir/duration/-/duration-7.1.2.tgz",
-            "integrity": "sha512-RpQ+29HisknHauOx7lhlNZVtVhprnvdD7JzL1Tlhqw+H6BLb34Jro51fpuVwyetJ5CeJ8LbOIDuUjx0ZlEid0A==",
-            "license": "(MIT or CC0 1.0)",
-            "peer": true,
-            "dependencies": {
-                "@types/luxon": "^3.4.2",
-                "luxon": "^3.5.0",
-                "type-fest": "^4.31.0"
-            },
-            "engines": {
-                "node": ">=22"
-            }
-        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.8",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
@@ -285,26 +230,6 @@
                 }
             }
         },
-        "node_modules/@types/luxon": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
-            "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/ansi-styles": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "node_modules/browser-or-node": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-3.0.0.tgz",
@@ -330,25 +255,12 @@
                 }
             }
         },
-        "node_modules/deep-eql": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/expect-type": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
-            "integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==",
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-0.15.0.tgz",
+            "integrity": "sha512-yWnriYB4e8G54M5/fAFj7rCIBiKs1HAACaY13kCz6Ku0dezjS9aMcfcdVK2X8Tv2tEV1BPz/wKfQ7WA4S/d8aA==",
             "license": "Apache-2.0",
-            "peer": true,
-            "engines": {
-                "node": ">=12.0.0"
-            }
+            "peer": true
         },
         "node_modules/globals": {
             "version": "11.12.0",
@@ -386,34 +298,11 @@
                 "node": ">=6"
             }
         },
-        "node_modules/json5": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-            "license": "MIT",
-            "peer": true,
-            "bin": {
-                "json5": "lib/cli.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "peer": true
-        },
-        "node_modules/luxon": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
-            "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=12"
-            }
         },
         "node_modules/ms": {
             "version": "2.1.3",
@@ -446,40 +335,77 @@
             }
         },
         "node_modules/prettier-plugin-multiline-arrays": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-multiline-arrays/-/prettier-plugin-multiline-arrays-4.0.2.tgz",
-            "integrity": "sha512-j8aWPMQl3QsTRR7e2HuNfwp429mB0IL1NQ8PjO0xq5W20O5L5h2XZ99vnqirceJizKhqhm8sOMmsmGcKEtlCFg==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-multiline-arrays/-/prettier-plugin-multiline-arrays-3.0.6.tgz",
+            "integrity": "sha512-FrWVa7MoDQo9b5XoLPrqIDClb0k+O8wOIsIr1DutRXhcerLY8PfIe/yYeTVD/vpRISkSXCBEYmj5Voe0wb5dEQ==",
             "license": "(MIT or CC0 1.0)",
             "peer": true,
             "dependencies": {
-                "@augment-vir/common": "^31.3.0",
-                "proxy-vir": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=22"
+                "@augment-vir/common": "^28.1.0",
+                "proxy-vir": "^1.0.0"
             },
             "peerDependencies": {
                 "prettier": ">=3.0.0"
             }
         },
         "node_modules/proxy-vir": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/proxy-vir/-/proxy-vir-2.0.1.tgz",
-            "integrity": "sha512-hjy5mWzHZhgRGh0f90f0Bz3VrGUe0T+AlhwnETakzRdvaN9RtPYLQG1+ZuEzSDK95FAhPYd26nEi1xVrXqvBwg==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/proxy-vir/-/proxy-vir-1.0.0.tgz",
+            "integrity": "sha512-WV1gkBxUOwLSz0Bn09tisIqLK7leAqtFm/474t3L0hQKJw7/gdrkGcWw0/OT1PhSy+TDS6swfq7Niuoq3XJhkQ==",
             "license": "(MIT or CC0 1.0)",
             "peer": true,
             "dependencies": {
-                "@augment-vir/assert": "^31.1.0",
-                "@augment-vir/common": "^31.1.0"
-            },
-            "engines": {
-                "node": ">=22"
+                "@augment-vir/common": "^23.3.4"
+            }
+        },
+        "node_modules/proxy-vir/node_modules/@augment-vir/common": {
+            "version": "23.4.0",
+            "resolved": "https://registry.npmjs.org/@augment-vir/common/-/common-23.4.0.tgz",
+            "integrity": "sha512-QIrJ1doD00TNbOzeVrk9KgPTzRlIjayxERnhtbQjK/AFPj5yElcB03GbnGdQZPzws/R+5gfMM5cZiH7QyBP+Kg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "browser-or-node": "^2.1.1",
+                "run-time-assertions": "^1.0.0",
+                "type-fest": "^4.10.2"
+            }
+        },
+        "node_modules/proxy-vir/node_modules/browser-or-node": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-2.1.1.tgz",
+            "integrity": "sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/run-time-assertions": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/run-time-assertions/-/run-time-assertions-1.5.2.tgz",
+            "integrity": "sha512-ccfwvjGuNU14cSSXLlmPRiqEgMfA7w3J2TViO79zMnzXGvE6FJ0dxnhIQGwe5r/vwySOJ4sqZksexo9wyAlA8g==",
+            "deprecated": "Use @augment-vir/assert instead.",
+            "license": "(MIT or CC0 1.0)",
+            "peer": true,
+            "dependencies": {
+                "@augment-vir/common": "^29.3.0",
+                "expect-type": "~0.15.0",
+                "type-fest": "^4.22.0"
+            }
+        },
+        "node_modules/run-time-assertions/node_modules/@augment-vir/common": {
+            "version": "29.3.0",
+            "resolved": "https://registry.npmjs.org/@augment-vir/common/-/common-29.3.0.tgz",
+            "integrity": "sha512-k3OX35/576thmGUzQUBcCKGarb7ONBfiu07+iV2vxmjl7VoB1rOB0vu8WqgB1ceJq2EMLDPXY18hHpJ9WeTHXQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "browser-or-node": "^3.0.0",
+                "run-time-assertions": "^1.5.1",
+                "type-fest": "^4.21.0"
             }
         },
         "node_modules/type-fest": {
-            "version": "4.33.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.33.0.tgz",
-            "integrity": "sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==",
+            "version": "4.34.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.34.1.tgz",
+            "integrity": "sha512-6kSc32kT0rbwxD6QL1CYe8IqdzN/J/ILMrNK+HMQCKH3insCDRY/3ITb0vcBss0a3t72fzh2YSzj8ko1HgwT3g==",
             "license": "(MIT OR CC0-1.0)",
             "peer": true,
             "engines": {
@@ -487,73 +413,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/typed-event-target": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/typed-event-target/-/typed-event-target-4.0.2.tgz",
-            "integrity": "sha512-vIAqC5HN/yuAn4+K4MFB6QBz4pAjp3se55KkRIbxX+EjGRyBJwbVasj2jgzUDhYeda9b0YbDng2N11A/bXvYwA==",
-            "license": "(MIT or CC0 1.0)",
-            "peer": true,
-            "dependencies": {
-                "@augment-vir/assert": "^30.3.0",
-                "@augment-vir/common": "^30.3.0",
-                "@augment-vir/core": "^30.3.0"
-            },
-            "engines": {
-                "node": ">=22"
-            }
-        },
-        "node_modules/typed-event-target/node_modules/@augment-vir/assert": {
-            "version": "30.8.4",
-            "resolved": "https://registry.npmjs.org/@augment-vir/assert/-/assert-30.8.4.tgz",
-            "integrity": "sha512-kxak+lDEYo14pStluTCss+/wH05SqlSv3mEN/yBvtV5lMJBXhoPcJGMua7zWXNCEnOCGVU36+hDBwuh9IQxT/A==",
-            "license": "(MIT or CC0 1.0)",
-            "peer": true,
-            "dependencies": {
-                "@augment-vir/core": "^30.8.4",
-                "@date-vir/duration": "^7.0.1",
-                "deep-eql": "^5.0.2",
-                "expect-type": "^1.1.0",
-                "type-fest": "^4.29.0"
-            },
-            "engines": {
-                "node": ">=22"
-            }
-        },
-        "node_modules/typed-event-target/node_modules/@augment-vir/common": {
-            "version": "30.8.4",
-            "resolved": "https://registry.npmjs.org/@augment-vir/common/-/common-30.8.4.tgz",
-            "integrity": "sha512-3w4WJOQKycuHmSod0BMjVyrUjHlHj+6vmabKvtRT96mz+b9Rstqg2EfM4zzlkuoM2k9biAbjeYSllwpmf631uQ==",
-            "license": "(MIT or CC0 1.0)",
-            "peer": true,
-            "dependencies": {
-                "@augment-vir/assert": "^30.8.4",
-                "@augment-vir/core": "^30.8.4",
-                "@date-vir/duration": "^7.0.1",
-                "ansi-styles": "^6.2.1",
-                "json5": "^2.2.3",
-                "type-fest": "^4.29.0",
-                "typed-event-target": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=22"
-            }
-        },
-        "node_modules/typed-event-target/node_modules/@augment-vir/core": {
-            "version": "30.8.4",
-            "resolved": "https://registry.npmjs.org/@augment-vir/core/-/core-30.8.4.tgz",
-            "integrity": "sha512-fOp0W+z2xkkkcH9lpsY6AUVp2vPbR5qo3fbVui9IrA4RJ6wXzio6+sP1yYw2iLJVmOOEYIWSbvZddDn+Ih6Ppw==",
-            "license": "(MIT or CC0 1.0)",
-            "peer": true,
-            "dependencies": {
-                "@date-vir/duration": "^7.0.1",
-                "browser-or-node": "^3.0.0",
-                "json5": "^2.2.3",
-                "type-fest": "^4.29.0"
-            },
-            "engines": {
-                "node": ">=22"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prettier": "./",
     "peerDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^5.2.1",
-        "prettier-plugin-multiline-arrays": "^4.0.2",
-        "prettier": "^3.4.2"
+        "prettier": "^3.4.2",
+        "prettier-plugin-multiline-arrays": "^3.0.6"
     }
 }


### PR DESCRIPTION
`prettier-plugin-multiline-arrays@4` introduced an engine dependency of `>=22`. With Stream Deck plugins running in Node.js, this results in a bad engine warning when installing the package.

Sadly, the alternative is a deprecation warning
```
run-time-assertions@1.5.2: Use @augment-vir/assert instead
```
This is, however, better than the bad engine warning.